### PR TITLE
build: fix build lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "build:lib": "vite build -- lib",
+    "build:lib": "vite build --config vite.config-lib.js",
     "preview": "vite preview",
     "publish": "npm publish dist/ --registry https://registry.npmjs.org",
     "lint": "eslint ./src --ext .vue,.js,.ts,.jsx,.tsx",

--- a/vite.config-lib.js
+++ b/vite.config-lib.js
@@ -1,0 +1,69 @@
+import vue from '@vitejs/plugin-vue2';
+import jsonfile from 'jsonfile';
+import path from 'path';
+import copy from 'rollup-plugin-copy';
+import { defineConfig } from 'vite';
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
+
+function editPackageJson() {
+  return {
+    name: 'edit-package-json',
+    closeBundle() {
+      const file = 'dist/package.json';
+      jsonfile.readFile(file, (err, obj) => {
+        if (!err) {
+          obj.main = 'umd/index.js';
+          obj.module = 'es/index.mjs';
+          jsonfile.writeFile(file, obj, { spaces: 2, EOL: '\r\n' });
+        }
+      });
+    },
+  };
+}
+
+const buildLib = {
+  lib: {
+    entry: path.resolve(__dirname, 'packages/el-select-v2'),
+    name: 'ElSelectV2',
+    fileName: format => {
+      if (format === 'es') {
+        return `${format}/index.mjs`;
+      }
+      return `${format}/index.js`;
+    },
+  },
+  rollupOptions: {
+    // 确保外部化处理那些你不想打包进库的依赖
+    external: ['vue', 'element-ui'],
+    output: {
+      // 在 UMD 构建模式下为这些外部化的依赖提供一个全局变量
+      globals: {
+        'vue': 'Vue',
+        'element-ui': 'ElementUI',
+      },
+    },
+    plugins: [
+      copy({
+        targets: [
+          { src: 'LICENSE', dest: 'dist' },
+          { src: 'README.md', dest: 'dist' },
+          { src: 'packages/el-select-v2/package.json', dest: 'dist' },
+        ],
+        hook: 'writeBundle',
+      }),
+      editPackageJson(),
+    ],
+  },
+};
+
+export default defineConfig({
+  base: './',
+  plugins: [vue(), cssInjectedByJsPlugin()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+    extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue'], // 扩展了.vue后缀
+  },
+  build: buildLib,
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,61 +1,6 @@
 import vue from '@vitejs/plugin-vue2';
-import jsonfile from 'jsonfile';
 import path from 'path';
-import copy from 'rollup-plugin-copy';
 import { defineConfig } from 'vite';
-import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
-
-function editPackageJson() {
-  return {
-    name: 'edit-package-json',
-    closeBundle() {
-      const file = 'dist/package.json';
-      jsonfile.readFile(file, (err, obj) => {
-        if (!err) {
-          obj.main = 'umd/index.js';
-          obj.module = 'es/index.mjs';
-          jsonfile.writeFile(file, obj, { spaces: 2, EOL: '\r\n' });
-        }
-      });
-    },
-  };
-}
-
-const buildLib = {
-  lib: {
-    entry: path.resolve(__dirname, 'packages/el-select-v2'),
-    name: 'ElSelectV2',
-    fileName: format => {
-      if (format === 'es') {
-        return `${format}/index.mjs`;
-      }
-      return `${format}/index.js`;
-    },
-  },
-  rollupOptions: {
-    // 确保外部化处理那些你不想打包进库的依赖
-    external: ['vue', 'element-ui'],
-    output: {
-      // 在 UMD 构建模式下为这些外部化的依赖提供一个全局变量
-      globals: {
-        'vue': 'Vue',
-        'element-ui': 'ElementUI',
-      },
-    },
-  },
-  plugins: [
-    cssInjectedByJsPlugin(),
-    copy({
-      targets: [
-        { src: 'LICENSE', dest: 'dist' },
-        { src: 'README.md', dest: 'dist' },
-        { src: 'packages/el-select-v2/package.json', dest: 'dist' },
-      ],
-      hook: 'writeBundle',
-    }),
-    editPackageJson(),
-  ],
-};
 
 const buildWebsite = {
   outDir: 'docs',
@@ -70,5 +15,5 @@ export default defineConfig({
     },
     extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue'], // 扩展了.vue后缀
   },
-  build: process.argv.includes('lib') ? buildLib : buildWebsite,
+  build: buildWebsite,
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,9 @@
-import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue2';
-import copy from 'rollup-plugin-copy';
-import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
 import jsonfile from 'jsonfile';
 import path from 'path';
+import copy from 'rollup-plugin-copy';
+import { defineConfig } from 'vite';
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
 
 function editPackageJson() {
   return {
@@ -42,19 +42,19 @@ const buildLib = {
         'element-ui': 'ElementUI',
       },
     },
-    plugins: [
-      cssInjectedByJsPlugin(),
-      copy({
-        targets: [
-          { src: 'LICENSE', dest: 'dist' },
-          { src: 'README.md', dest: 'dist' },
-          { src: 'packages/el-select-v2/package.json', dest: 'dist' },
-        ],
-        hook: 'writeBundle',
-      }),
-      editPackageJson(),
-    ],
   },
+  plugins: [
+    cssInjectedByJsPlugin(),
+    copy({
+      targets: [
+        { src: 'LICENSE', dest: 'dist' },
+        { src: 'README.md', dest: 'dist' },
+        { src: 'packages/el-select-v2/package.json', dest: 'dist' },
+      ],
+      hook: 'writeBundle',
+    }),
+    editPackageJson(),
+  ],
 };
 
 const buildWebsite = {


### PR DESCRIPTION
```bash
node -v
v20.16.0

npm run build:lib

> el-select-v2@0.0.0 build:lib
> vite build -- lib

vite v6.2.2 building for production...
✓ 129 modules transformed.
dist/el-select-v2.css   2.21 kB │ gzip:  0.60 kB
dist/es/index.mjs      70.30 kB │ gzip: 19.80 kB
dist/el-select-v2.css   2.21 kB │ gzip:  0.60 kB
dist/umd/index.js      49.88 kB │ gzip: 17.18 kB
✓ built in 493ms
```